### PR TITLE
删除《分段显示器化简理论》和《处理器结构》

### DIFF
--- a/chapters/chapter7.tex
+++ b/chapters/chapter7.tex
@@ -612,25 +612,3 @@ $$
 1
 \subsection{栈（Stack）}
 1
-
-\section{分段显示器化简理论}
-1
-\subsection{分段显示器主要结构}
-1
-\subsection{显示矩阵、分段矩阵和数字矩阵}
-1
-\subsection{矩阵的初等变换}
-1
-\subsection{化简原理与细节}
-1
-
-\section{处理器结构}
-1
-\subsection{汇编语言}
-1
-\subsection{机器语言}
-1
-\subsection{处理器的拓扑结构}
-1
-\subsection{数据路径（Data Path）}
-1


### PR DESCRIPTION
《分段显示器化简理论》将出现在《代数理论》中

《处理器结构》没有更新计划，故删除